### PR TITLE
Fix deprecated texture node preview usage

### DIFF
--- a/operators/utils/bgis_utils.py
+++ b/operators/utils/bgis_utils.py
@@ -135,7 +135,7 @@ def addTexture(mat, img, uvLay, name='texture'):
 	textureNode = node_tree.nodes.new('ShaderNodeTexImage')
 	textureNode.image = img
 	textureNode.extension = 'CLIP'
-	textureNode.show_texture = True
+	textureNode.show_preview = True
 	textureNode.location = (-400, 200)
 	# Create BSDF diffuse node
 	diffuseNode = node_tree.nodes.new('ShaderNodeBsdfPrincipled')#ShaderNodeBsdfDiffuse


### PR DESCRIPTION
## Summary
- update texture node creation helper to use `show_preview` instead of removed `show_texture`

## Testing
- `python -m py_compile operators/utils/bgis_utils.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a0d9ae1d348331ad8d17cd3e270694