### PR TITLE
Cleanup unused and duplicate imports

### DIFF
--- a/clients/QtMapServiceClient.py
+++ b/clients/QtMapServiceClient.py
@@ -1,6 +1,5 @@
 # -*- coding:utf-8 -*-
 import sys, os, time
-import sys, os
 sys.path.append(os.path.abspath('..'))
 
 from PyQt4 import QtGui, QtCore, uic

--- a/operators/nodes_terrain_analysis_reclassify.py
+++ b/operators/nodes_terrain_analysis_reclassify.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 from .utils import getBBOX
 
-from ..core.utils.gradient import Color, Stop, Gradient
+from ..core.utils.gradient import Color, Gradient
 
 from ..core.maths.interpo import scale
 from ..core.maths.kmeans1D import kmeans1d, getBreaks


### PR DESCRIPTION
## Summary
- remove unused Stop import in reclassify operator
- drop redundant sys/os import in Qt map service client

## Testing
- `python -m py_compile operators/nodes_terrain_analysis_reclassify.py`
- `python -m py_compile clients/QtMapServiceClient.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0de2e29cc833195b0ee218ac57d57