### PR TITLE
Improve Norwegian geodata defaults and strengthen NVDB import robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Note : Since 2022, the OpenTopography web service requires an API key. Please re
 
 ## Functionalities overview
 
+
+## Recommended setup for Norway / Statens vegvesen
+
+For projects that require authoritative Norwegian geodata, prefer:
+
+- **Kartverket / Geonorge** basemaps (WMTS/WMS) in the map viewer.
+- **NVDB road network importer** for Statens vegvesen road centerlines.
+
+OpenStreetMap and Google layers can still be useful for quick context, but should be treated as non-authoritative background sources.
+
 **GIS datafile import :** Import in Blender most commons GIS data format : Shapefile vector, raster image, geotiff DEM, OpenStreetMap xml.
 
 There are a lot of possibilities to create a 3D terrain from geographic data with BlenderGIS, check the [Flowchart](https://raw.githubusercontent.com/wiki/domlysz/blenderGIS/flowchart.jpg) to have an overview.

--- a/__init__.py
+++ b/__init__.py
@@ -226,10 +226,10 @@ class VIEW3D_MT_menu_gis_webgeodata(bpy.types.Menu):
 	def draw(self, context):
 		if BASEMAPS:
 			self.layout.operator("view3d.map_start", icon_value=icons_dict["layers"].icon_id)
-		if IMPORT_OSM:
-			self.layout.operator("importgis.osm_query", icon_value=icons_dict["osm"].icon_id)
 		if IMPORT_NVDB:
-			self.layout.operator("importgis.nvdb_query")
+			self.layout.operator("importgis.nvdb_query", text="NVDB vegnett (Statens vegvesen)")
+		if IMPORT_OSM:
+			self.layout.operator("importgis.osm_query", icon_value=icons_dict["osm"].icon_id, text="OpenStreetMap (uoffisiell)")
 		if GET_DEM:
 			self.layout.operator("importgis.dem_query", icon_value=icons_dict["raster"].icon_id)
 

--- a/core/basemaps/servicesDefs.py
+++ b/core/basemaps/servicesDefs.py
@@ -152,7 +152,7 @@ SOURCES = {
 
 	"KARTVERKET" : {
 		"name" : 'Kartverket (Norge)',
-		"description" : 'Offisielle bakgrunnskart fra Kartverket cache-tjeneste',
+		"description" : 'Offisielle bakgrunnskart fra Kartverket (anbefalt for Norge)',
 		"service": 'TMS',
 		"grid": 'WM',
 		"quadTree": False,
@@ -167,7 +167,7 @@ SOURCES = {
 
 	"GEONORGE_GRUNNKART" : {
 		"name" : 'Geonorge grunnkart',
-		"description" : 'Norges grunnkart via Kartverket WMTS (gatekeeper)',
+		"description" : 'Norges grunnkart via Kartverket WMTS (offisiell kilde)',
 		"service": 'WMTS',
 		"grid": 'WM',
 		"matrix" : 'webmercator',
@@ -206,7 +206,7 @@ SOURCES = {
 
 	"GOOGLE" : {
 		"name" : 'Google',
-		"description" : 'Google map',
+		"description" : 'Google map (ikke offisiell kilde)',
 		"service": 'TMS',
 		"grid": 'WM',
 		"quadTree": False,
@@ -221,7 +221,7 @@ SOURCES = {
 
 	"OSM" : {
 		"name" : 'OSM',
-		"description" : 'Open Street Map',
+		"description" : 'OpenStreetMap (crowdsourcet, ikke offisiell kilde)',
 		"service": 'TMS',
 		"grid": 'WM',
 		"quadTree": False,


### PR DESCRIPTION
### Motivation

- Make BlenderGIS more suitable for Norwegian public-sector workflows by prioritizing authoritative national sources (Kartverket/Geonorge) and the Statens vegvesen NVDB API for road data. 
- Harden the NVDB importer to reliably handle larger extents and network conditions encountered in production use.

### Description

- Added paginated fetching to the NVDB importer (`_fetch_all_pages` / `metadata.neste.href`) and an item normalizer (`_collect_items`) so results spanning multiple pages are retrieved. 
- Improved network/error handling using `HTTPError`/`URLError`, added an `X-Client` header, and clearer user-facing error messages. 
- Exposed importer controls `max_segments` (`IntProperty`) and `merge_segments` (`BoolProperty`) and added logic to limit result size and optionally merge all segments into a single mesh for performance. 
- Updated UI and defaults to emphasize NVDB in the “Web geodata” menu and relabel OSM/Google as non-authoritative, adjusted basemap descriptions in `core/basemaps/servicesDefs.py`, and added a README section recommending Kartverket/Geonorge + NVDB for Norway. 

### Testing

- Compiled modified modules successfully with `python -m py_compile operators/io_import_nvdb.py` which returned `OK`. 
- Compiled the set `__init__.py`, `operators/io_import_nvdb.py`, and `core/basemaps/servicesDefs.py` with `python -m py_compile __init__.py operators/io_import_nvdb.py core/basemaps/servicesDefs.py` and the compilation completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69933aab57588331b2f8451795a84341)